### PR TITLE
Refactor: move UserDisplaySerializer for better modular separation

### DIFF
--- a/apps/ride/serializers.py
+++ b/apps/ride/serializers.py
@@ -1,19 +1,12 @@
 from rest_framework import serializers
 from apps.ride.models import Ride, RideEvent
 from apps.user.models import User
-
-
-class UserDisplaySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ['id', 'first_name', 'last_name', 'email']
-
+from apps.user.serializers import UserDisplaySerializer
 
 class RideEventSerializer(serializers.ModelSerializer):
     class Meta:
         model = RideEvent
         fields = ['id_ride_event', 'description', 'created_at']
-
 
 class RideSerializer(serializers.ModelSerializer):
     id_rider = UserDisplaySerializer(read_only=True)

--- a/apps/user/serializers.py
+++ b/apps/user/serializers.py
@@ -49,3 +49,8 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
         return user
+    
+class UserDisplaySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'first_name', 'last_name', 'email']


### PR DESCRIPTION
- Moved UserDisplaySerializer from ride app to user app since it handles user data.
- Updated import in ride serializers to reference the relocated serializer.
- This keeps serializers.py on ride app focused only on ride-related logic.