### PR TITLE
Refactor(permissions): define ADMIN_ROLE_NAME as constant variable

### DIFF
--- a/apps/user/permissions.py
+++ b/apps/user/permissions.py
@@ -1,12 +1,14 @@
 from rest_framework.permissions import BasePermission
 
+ADMIN_ROLE_NAME = "Admin"
+
 class IsAdminRole(BasePermission):
     """
-    Grants access only to users with Admin users
+    Grants access only to users with Admin role
     """
     def has_permission(self, request, view):
         return (
             request.user.is_authenticated and 
             hasattr(request.user, 'user_type') and 
-            request.user.user_type.name == "Admin"
+            request.user.user_type.name == ADMIN_ROLE_NAME
         )


### PR DESCRIPTION
- Moved 'Admin' role name to a top-level constant to avoid magic strings
- Used constant in IsAdminRole permission check for clarity and reusability